### PR TITLE
fix: 중성코드표 오류 수정

### DIFF
--- a/lib/ununiga/jaso_splitter.rb
+++ b/lib/ununiga/jaso_splitter.rb
@@ -17,7 +17,7 @@ module Ununiga
   # 
   class JasoSplitter
     CHOSUNGS = %w(ㄱ ㄲ ㄴ ㄷ ㄸ ㄹ ㅁ ㅂ ㅃ ㅅ ㅆ ㅇ ㅈ ㅉ ㅊ ㅋ ㅌ ㅍ ㅎ).freeze
-    JUNGSUNGS = %w(ㅏ ㅐ ㅑ ㅒ ㅓ ㅔ ㅕ ㅖ ㅗ ㅘ ㅛ ㅙ ㅚ ㅜ ㅝ ㅞ ㅟ ㅠ ㅡ ㅢ ㅣ).freeze
+    JUNGSUNGS = %w(ㅏ ㅐ ㅑ ㅒ ㅓ ㅔ ㅕ ㅖ ㅗ ㅘ ㅙ ㅚ ㅛ ㅜ ㅝ ㅞ ㅟ ㅠ ㅡ ㅢ ㅣ).freeze
     JONGSUNGS = %w(ㄱ ㄲ ㄳ ㄴ ㄵ ㄶ ㄷ ㄹ ㄺ ㄻ ㄼ ㄽ ㄾ ㄿ ㅀ ㅁ ㅂ ㅄ ㅅ ㅆ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎ).unshift(nil).freeze
     KR_RANGE = ('가'.unpack('U')[0]..'힣'.unpack('U')[0]).freeze
     KR_OFFSET = KR_RANGE.first.freeze

--- a/test/test_jaso_splitter.rb
+++ b/test/test_jaso_splitter.rb
@@ -18,7 +18,9 @@ class JamoSplitterTest < Minitest::Unit::TestCase
     testgroup = { '가' => 'ㅏ',
                   '내' => 'ㅐ',
                   '찋' => 'ㅢ',
-                  '휷' => 'ㅠ'
+                  '휷' => 'ㅠ',
+                  '쿄' => 'ㅛ',
+                  '왜' => 'ㅙ'
                 }
     testgroup.each do |char, jungsung|
       splitter = Ununiga::JasoSplitter.new(char)
@@ -41,7 +43,8 @@ class JamoSplitterTest < Minitest::Unit::TestCase
   def test_split
     testgroup = { '신' => ['ㅅ', 'ㅣ', 'ㄴ'],
                   '재' => ['ㅈ', 'ㅐ', nil],
-                  '현' => ['ㅎ', 'ㅕ', 'ㄴ']
+                  '현' => ['ㅎ', 'ㅕ', 'ㄴ'],
+                  '꾢' => ['ㄲ', 'ㅛ', 'ㄶ']
                 }
     testgroup.each do |char, splitted|
       splitter = Ununiga::JasoSplitter.new(char)


### PR DESCRIPTION
중성코드표 오류로 인해, 'ㅛ', 'ㅙ' 등의 중성이 잘못 출력되어 수정