### PR TITLE
Add: HTML 문자열 지원 추가

### DIFF
--- a/lib/ununiga/i18n/josa_transformer.rb
+++ b/lib/ununiga/i18n/josa_transformer.rb
@@ -2,13 +2,13 @@ require 'ununiga/josa_picker'
 
 module Ununiga::I18n
   module JosaTransformer
-    def translate(*args)
-      transform(super)
+    def translate(locale, key, options = {})
+      transform(super, key.end_with?("_html", ".html"))
     end
 
-    def transform(entry)
+    def transform(entry, is_html)
       if entry.is_a?(String) && I18n.locale.to_s =~ /ko|ko_KR/i
-        return Ununiga::JosaPicker.new(entry).takewell
+        return Ununiga::JosaPicker.new(entry, is_html).takewell
       end
       entry
     end

--- a/lib/ununiga/josa_picker.rb
+++ b/lib/ununiga/josa_picker.rb
@@ -12,7 +12,7 @@ module Ununiga
              %w(이),
             ].freeze
 
-    attr_reader :korean_str
+    attr_reader :korean_str, :is_html
 
     class << self
       def takewell(str)
@@ -20,8 +20,9 @@ module Ununiga
       end
     end
 
-    def initialize(str)
+    def initialize(str, is_html = false)
       @korean_str = str
+      @is_html = is_html
     end
 
     def takewell
@@ -31,7 +32,12 @@ module Ununiga
           matched
         else
           josa = JOSAS.find { |jo| josa_convension(jo).include? matched }
-          splitter = JasoSplitter.new(korean_str[index - 1])
+          preceding_char = if is_html
+            korean_str[0...index].gsub(/<[^>]*>/, "")[-1]
+          else
+            korean_str[index - 1]
+          end
+          splitter = JasoSplitter.new(preceding_char)
           josa[(splitter.jongsung ? 0 : 1)]
         end
       end

--- a/test/test.yml
+++ b/test/test.yml
@@ -2,6 +2,9 @@ ko:
   someone_pay: '%{name}이(가) 돈을 냅니다.'
   someone_eat_something: '%{name}은(는) %{meal}을(를) 먹습니다.'
   do_something_with_someone: '%{name1}와(과) %{name2}은(는) %{doing}을(를) 합니다.'
+  someone_pay_html: '<b>%{name}</b>이(가) 돈을 냅니다.'
+  someone_eat_nesting:
+    html: '<b>%{name}</b>은(는) <b>%{meal}</b>을(를) 먹습니다.'
   float_value: 234.234234
   nested_value:
     first: '1'

--- a/test/test_josa_transformer.rb
+++ b/test/test_josa_transformer.rb
@@ -15,12 +15,19 @@ class JosaTransformerTest < Minitest::Test
     assert_equal '철수가 돈을 냅니다.', I18n.t(:someone_pay, name: '철수')
     assert_equal '재현이 돈을 냅니다.', I18n.t(:someone_pay, name: '재현')
 
-
     assert_equal '호랑이는 사과를 먹습니다.', I18n.t(:someone_eat_something, name: '호랑이', meal: '사과')
     assert_equal '곰은 마늘을 먹습니다.', I18n.t(:someone_eat_something, name: '곰', meal: '마늘')
 
     assert_equal '재현과 진아는 개발을 합니다.', I18n.t(:do_something_with_someone, name1: '재현', name2: '진아', doing: '개발')
     assert_equal '정하와 민정은 디자인을 합니다.', I18n.t(:do_something_with_someone, name1: '정하', name2: '민정', doing: '디자인')
+  end
+
+  def test_transform_korean_with_html
+    assert_equal '<b>철수</b>가 돈을 냅니다.', I18n.t(:someone_pay_html, name: '철수')
+    assert_equal '<b>재현</b>이 돈을 냅니다.', I18n.t(:someone_pay_html, name: '재현')
+
+    assert_equal '<b>호랑이</b>는 <b>사과</b>를 먹습니다.', I18n.t("someone_eat_nesting.html", name: '호랑이', meal: '사과')
+    assert_equal '<b>곰</b>은 <b>마늘</b>을 먹습니다.', I18n.t("someone_eat_nesting.html", name: '곰', meal: '마늘')
   end
 
   def test_not_string_locale_value


### PR DESCRIPTION
안녕하세요.
[HTML 번역](https://guides.rubyonrails.org/i18n.html#using-safe-html-translations)의 경우 제대로 조사 판단을 하지 못하는 문제가 있어서 테스트와 함께 수정해 보았습니다.
구체적으로는, 위 문서에 나온 것과 같은 형태의 key를 쓰는 경우 조사 앞의 문자열에서 태그를 제거하고 판단하도록 했습니다. 이를 위해 키를 알아야 해서 translate의 시그니처를 [I18n::Backend::Base#translate](https://github.com/ruby-i18n/i18n/blob/baf8a889391c7877ffe3a2bb61ea5465d2c9dc38/lib/i18n/backend/base.rb#L28)에 맞추는 한편 JosaPicker에는 속성을 추가했습니다.
젬 잘 사용하고 있습니다. 감사합니다.
