### PR TITLE
Update: locale 파라미터값이 ko 인경우에도 라이브러리 적용

### DIFF
--- a/lib/ununiga/i18n/josa_transformer.rb
+++ b/lib/ununiga/i18n/josa_transformer.rb
@@ -3,11 +3,11 @@ require 'ununiga/josa_picker'
 module Ununiga::I18n
   module JosaTransformer
     def translate(locale, key, options = {})
-      transform(super, key.end_with?("_html", ".html"))
+      transform(super, key.end_with?("_html", ".html"), locale)
     end
 
-    def transform(entry, is_html)
-      if entry.is_a?(String) && I18n.locale.to_s =~ /ko|ko_KR/i
+    def transform(entry, is_html, locale=I18n.locale)
+      if entry.is_a?(String) && locale.to_s =~ /ko|ko_KR/i
         return Ununiga::JosaPicker.new(entry, is_html).takewell
       end
       entry

--- a/test/test_josa_transformer.rb
+++ b/test/test_josa_transformer.rb
@@ -30,6 +30,16 @@ class JosaTransformerTest < Minitest::Test
     assert_equal '<b>곰</b>은 <b>마늘</b>을 먹습니다.', I18n.t("someone_eat_nesting.html", name: '곰', meal: '마늘')
   end
 
+  def test_global_locale_not_ko
+    I18n.locale = :en
+    assert_equal '철수가 돈을 냅니다.', I18n.t(:someone_pay, name: '철수', locale: :ko)
+    assert_equal '재현이 돈을 냅니다.', I18n.t(:someone_pay, name: '재현', locale: :ko)
+
+    assert_equal '호랑이는 사과를 먹습니다.', I18n.t(:someone_eat_something, name: '호랑이', meal: '사과', locale: :ko)
+    assert_equal '곰은 마늘을 먹습니다.', I18n.t(:someone_eat_something, name: '곰', meal: '마늘', locale: :ko)
+    I18n.locale = :ko
+  end
+
   def test_not_string_locale_value
     assert_equal 234.234234, I18n.t(:float_value)
     assert_equal ({ first: '1', second: '2' }), I18n.t(:nested_value)


### PR DESCRIPTION
### 차이점

기존에는 I18n.locale값에 따라서 라이브러리의 적용여부가 결정됨
수정후에는 locale 파라미터값이 I18n.locale값보다 우선시됨